### PR TITLE
Export as d3.geom.concaveHull not d3.layout.concaveHull

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var d3 = require('d3');
 
-d3.layout.concaveHull = require('./src/concaveHull');
+d3.geom.concaveHull = require('./src/concaveHull');
 
 module.exports = d3;


### PR DESCRIPTION
All the examples use d3.geom.concaveHull but the module exports as d3.layout.concaveHull

Suspect this was just a typo